### PR TITLE
feat: rework forward permissions

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,8 +1,8 @@
 pub struct Parameters {
     pub bot_name: String,
-    pub pro_chat_id: i64,
+    pub pro_chat_id: teloxide::types::ChatId,
     pub pro_chat_username: String,
-    pub supapro_chat_id: i64,
+    pub supapro_chat_id: teloxide::types::ChatId,
     pub supapro_chat_username: String,
     pub is_webhook_mode_enabled: bool,
 }
@@ -11,18 +11,22 @@ impl Parameters {
     pub fn new() -> Self {
         let bot_name = std::env::var("BOT_NAME").expect("BOT_NAME env var is not specified");
 
-        let pro_chat_id: i64 = std::env::var("PRO_CHAT_ID")
-            .expect("SUPAPRO_CHAT_ID env var is not specified")
-            .parse()
-            .expect("Cannot parse as i64");
+        let pro_chat_id = teloxide::types::ChatId(
+            std::env::var("PRO_CHAT_ID")
+                .expect("SUPAPRO_CHAT_ID env var is not specified")
+                .parse()
+                .expect("Cannot parse as i64"),
+        );
 
         let pro_chat_username: String =
             std::env::var("PRO_CHAT_USERNAME").expect("PRO_CHAT_USERNAME env var is not specified");
 
-        let supapro_chat_id: i64 = std::env::var("SUPAPRO_CHAT_ID")
-            .expect("SUPAPRO_CHAT_ID env var is not specified")
-            .parse()
-            .expect("Cannot parse as i64");
+        let supapro_chat_id = teloxide::types::ChatId(
+            std::env::var("SUPAPRO_CHAT_ID")
+                .expect("SUPAPRO_CHAT_ID env var is not specified")
+                .parse()
+                .expect("Cannot parse as i64"),
+        );
 
         let supapro_chat_username: String = std::env::var("SUPAPRO_CHAT_USERNAME")
             .expect("SUPAPRO_CHAT_USERNAME env var is not specified");


### PR DESCRIPTION
- now it is possible to use forward from specified in the config chats

Tested:
- Local run